### PR TITLE
Update class-wc-gateway-pay-later.php line 64

### DIFF
--- a/includes/gateways/pay-later/class-wc-gateway-pay-later.php
+++ b/includes/gateways/pay-later/class-wc-gateway-pay-later.php
@@ -60,8 +60,8 @@ class WC_Gateway_Pay_Later extends WC_Payment_Gateway {
 	 * Change the default order status to on-hold so that pending order emails can be triggered
 	 */
 	public function default_order_status($default) {
-		
-		if( ! is_admin() && WC()->session->set( 'chosen_payment_method') == $this->id ) {
+		/* if( ! is_admin() && WC()->session->set( 'chosen_payment_method') == $this->id ) {*/
+		if( ! is_admin() && WC()->session->get( 'chosen_payment_method') == $this->id ) {
 			
 			$default = 'on-hold';
 			


### PR DESCRIPTION
In Woocommerce 3.08 I saw an error: Missing argument 2 for WC_Session::set() on line 64.
I have edited this line & replaced "set" with "get". Ant there is no other errors displayed in website.
Full error information: Warning: Missing argument 2 for WC_Session::set(), called in /plugins/woocommerce-pay-later-master/includes/gateways/pay-later/class-wc-gateway-pay-later.php on line 64 and defined in /home2/rgdcanad/public_html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-session.php on line 82